### PR TITLE
Show GetMoreTokensModal if a user has 0 notification tokens

### DIFF
--- a/app/javascript/components/ListCard/Buttons/RelationshipButtons.tsx
+++ b/app/javascript/components/ListCard/Buttons/RelationshipButtons.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { useState } from 'react'
 import RequestButton from '../../RequestButton'
 import ConfirmModal from '../../ConfirmModal'
+import GetMoreTokensModal from '../../GetTokensButton/GetMoreTokensModal'
 import { StarIcon as StarIconSolid, BellIcon as BellIconSolid } from '@heroicons/react/solid'
 import { StarIcon as StarIconOutline, BellIcon as BellIconOutline } from '@heroicons/react/outline'
 
@@ -68,9 +69,6 @@ function UntoggledSubscribeButton({ sectionId, onClick }: ButtonProps): JSX.Elem
   if (phone === null) {
     description = "You don't currently have a phone number set. Go over to Settings to add your number!"
     subscribeDisabled = true
-  } else if (subscribeDisabled) {
-    description = 'You currently have 0 notification tokens. Try writing some reviews to gain notification tokens!'
-    subscribeDisabled = true
   } else {
     description = `You will receive text message alerts to ${phone} about enrollment changes to this class. Message and data rates may apply. You may unsubscribe at any time in your settings page. This subscription will use one of your ${notificationTokens} notification tokens. To obtain more notification tokens, write reviews for classes you've taken.`
   }
@@ -86,21 +84,25 @@ function UntoggledSubscribeButton({ sectionId, onClick }: ButtonProps): JSX.Elem
       >
         <BellIconOutline className="h-5 w-5" />
       </RequestButton>
-      <ConfirmModal
-        title="Confirm subscription"
-        description={description}
-        isOpen={isModalOpen}
-        Icon={BellIconOutline}
-        onConfirm={onConfirm}
-        onCancel={() => setIsModalOpen(false)}
-        confirmDisabled={subscribeDisabled}
-        confirmLabel="Subscribe"
-        confirmRequest={{
-          method: 'POST',
-          resource: '/relationships',
-          body: { section_id: sectionId, subscribe: true },
-        }}
-      />
+      {subscribeDisabled ? (
+        <GetMoreTokensModal open={isModalOpen} setOpen={setIsModalOpen} />
+      ) : (
+        <ConfirmModal
+          title="Confirm subscription"
+          description={description}
+          isOpen={isModalOpen}
+          Icon={BellIconOutline}
+          onConfirm={onConfirm}
+          onCancel={() => setIsModalOpen(false)}
+          confirmDisabled={subscribeDisabled}
+          confirmLabel="Subscribe"
+          confirmRequest={{
+            method: 'POST',
+            resource: '/relationships',
+            body: { section_id: sectionId, subscribe: true },
+          }}
+        />
+      )}
     </>
   )
 }

--- a/app/javascript/components/ListCard/Buttons/RelationshipButtons.tsx
+++ b/app/javascript/components/ListCard/Buttons/RelationshipButtons.tsx
@@ -64,8 +64,9 @@ function UntoggledSubscribeButton({ sectionId, onClick }: ButtonProps): JSX.Elem
     if (onClick) onClick()
   }
 
-  let subscribeDisabled = notificationTokens === 0
-  let description
+  const showGetMoreTokensModal = notificationTokens === 0
+  let subscribeDisabled = false
+  let description: string | null = null
   if (phone === null) {
     description = "You don't currently have a phone number set. Go over to Settings to add your number!"
     subscribeDisabled = true
@@ -84,7 +85,7 @@ function UntoggledSubscribeButton({ sectionId, onClick }: ButtonProps): JSX.Elem
       >
         <BellIconOutline className="h-5 w-5" />
       </RequestButton>
-      {subscribeDisabled ? (
+      {showGetMoreTokensModal ? (
         <GetMoreTokensModal open={isModalOpen} setOpen={setIsModalOpen} />
       ) : (
         <ConfirmModal


### PR DESCRIPTION
## Description

<!--- What this PR does, why we're making it, etc. -->

Instead of a modal telling users that they must go write a review, we pop up the get more tokens modal to show the different ways to get tokens!

<img width="1051" alt="Screen Shot 2022-09-17 at 1 42 23 PM" src="https://user-images.githubusercontent.com/5677971/190875765-4597a924-b396-4c8b-9a2a-4f92461461e9.png">


## Deployment

- [x] I am making a frontend change, which will be auto-deployed via Heroku.
- [ ] I am making a Ruby change, which will be auto-deployed via Heroku.
  - [ ] I have added one or more gems, and run `rake sorbet:update:all` to generate their types.
  - [ ] I have added or changed a model, and run `rake sorbet:update:all` to generate their types.
- [ ] I am making a database change, which I will manually deploy after my branch is merged.
  - [ ] I have migrated the database using `env RAILS_ENV=production rails db:migrate`.
  - [ ] I have updated the entity relationship diagram via `bundle exec erd`.
  - [ ] I have updated the affected Administrate model dashboards to reflect my DB changes.
- [ ] I am making a Go Lambda change, which I will manually deploy after my branch is merged.
  - [ ] I have deployed the lambdas using `make deploy`.
- [ ] There are other deployment steps I must take after merge, which are:
