### PR TITLE
Add Summer 2022 calendar for scraping

### DIFF
--- a/lib/tasks/scrape.rake
+++ b/lib/tasks/scrape.rake
@@ -64,6 +64,7 @@ summer_session_dates_map = T.let(
     '2019' => 'lib/tasks/scrapedata/summer_session_dates/summer-calendar-2019-2020.html',
     '2020' => 'lib/tasks/scrapedata/summer_session_dates/summer-calendar-2019-2020.html',
     '2021' => 'lib/tasks/scrapedata/summer_session_dates/summer-calendar-2021.html',
+    '2022' => 'lib/tasks/scrapedata/summer_session_dates/summer-calendar-2022.html',
   },
   T::Hash[String, String],
 )

--- a/lib/tasks/scrapedata/summer_session_dates/summer-calendar-2022.html
+++ b/lib/tasks/scrapedata/summer_session_dates/summer-calendar-2022.html
@@ -1,0 +1,259 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+<meta http-equiv="X-UA-Compatible" content="IE=edge"><script type="text/javascript">(window.NREUM||(NREUM={})).init={privacy:{cookies_enabled:true},ajax:{deny_list:["bam.nr-data.net"]}};(window.NREUM||(NREUM={})).loader_config={licenseKey:"NRJS-7be76d7c7bc415dd4df",applicationID:"1468364564"};window.NREUM||(NREUM={}),__nr_require=function(t,e,n){function r(n){if(!e[n]){var i=e[n]={exports:{}};t[n][0].call(i.exports,function(e){var i=t[n][1][e];return r(i||e)},i,i.exports)}return e[n].exports}if("function"==typeof __nr_require)return __nr_require;for(var i=0;i<n.length;i++)r(n[i]);return r}({1:[function(t,e,n){function r(){}function i(t,e,n,r){return function(){return s.recordSupportability("API/"+e+"/called"),o(t+e,[u.now()].concat(c(arguments)),n?null:this,r),n?void 0:this}}var o=t("handle"),a=t(9),c=t(10),f=t("ee").get("tracer"),u=t("loader"),s=t(4),d=NREUM;"undefined"==typeof window.newrelic&&(newrelic=d);var p=["setPageViewName","setCustomAttribute","setErrorHandler","finished","addToTrace","inlineHit","addRelease"],l="api-",v=l+"ixn-";a(p,function(t,e){d[e]=i(l,e,!0,"api")}),d.addPageAction=i(l,"addPageAction",!0),d.setCurrentRouteName=i(l,"routeName",!0),e.exports=newrelic,d.interaction=function(){return(new r).get()};var m=r.prototype={createTracer:function(t,e){var n={},r=this,i="function"==typeof e;return o(v+"tracer",[u.now(),t,n],r),function(){if(f.emit((i?"":"no-")+"fn-start",[u.now(),r,i],n),i)try{return e.apply(this,arguments)}catch(t){throw f.emit("fn-err",[arguments,this,t],n),t}finally{f.emit("fn-end",[u.now()],n)}}}};a("actionText,setName,setAttribute,save,ignore,onEnd,getContext,end,get".split(","),function(t,e){m[e]=i(v,e)}),newrelic.noticeError=function(t,e){"string"==typeof t&&(t=new Error(t)),s.recordSupportability("API/noticeError/called"),o("err",[t,u.now(),!1,e])}},{}],2:[function(t,e,n){function r(t){if(NREUM.init){for(var e=NREUM.init,n=t.split("."),r=0;r<n.length-1;r++)if(e=e[n[r]],"object"!=typeof e)return;return e=e[n[n.length-1]]}}e.exports={getConfiguration:r}},{}],3:[function(t,e,n){var r=!1;try{var i=Object.defineProperty({},"passive",{get:function(){r=!0}});window.addEventListener("testPassive",null,i),window.removeEventListener("testPassive",null,i)}catch(o){}e.exports=function(t){return r?{passive:!0,capture:!!t}:!!t}},{}],4:[function(t,e,n){function r(t,e){var n=[a,t,{name:t},e];return o("storeMetric",n,null,"api"),n}function i(t,e){var n=[c,t,{name:t},e];return o("storeEventMetrics",n,null,"api"),n}var o=t("handle"),a="sm",c="cm";e.exports={constants:{SUPPORTABILITY_METRIC:a,CUSTOM_METRIC:c},recordSupportability:r,recordCustom:i}},{}],5:[function(t,e,n){function r(){return c.exists&&performance.now?Math.round(performance.now()):(o=Math.max((new Date).getTime(),o))-a}function i(){return o}var o=(new Date).getTime(),a=o,c=t(11);e.exports=r,e.exports.offset=a,e.exports.getLastTimestamp=i},{}],6:[function(t,e,n){function r(t,e){var n=t.getEntries();n.forEach(function(t){"first-paint"===t.name?l("timing",["fp",Math.floor(t.startTime)]):"first-contentful-paint"===t.name&&l("timing",["fcp",Math.floor(t.startTime)])})}function i(t,e){var n=t.getEntries();if(n.length>0){var r=n[n.length-1];if(u&&u<r.startTime)return;var i=[r],o=a({});o&&i.push(o),l("lcp",i)}}function o(t){t.getEntries().forEach(function(t){t.hadRecentInput||l("cls",[t])})}function a(t){var e=navigator.connection||navigator.mozConnection||navigator.webkitConnection;if(e)return e.type&&(t["net-type"]=e.type),e.effectiveType&&(t["net-etype"]=e.effectiveType),e.rtt&&(t["net-rtt"]=e.rtt),e.downlink&&(t["net-dlink"]=e.downlink),t}function c(t){if(t instanceof y&&!w){var e=Math.round(t.timeStamp),n={type:t.type};a(n),e<=v.now()?n.fid=v.now()-e:e>v.offset&&e<=Date.now()?(e-=v.offset,n.fid=v.now()-e):e=v.now(),w=!0,l("timing",["fi",e,n])}}function f(t){"hidden"===t&&(u=v.now(),l("pageHide",[u]))}if(!("init"in NREUM&&"page_view_timing"in NREUM.init&&"enabled"in NREUM.init.page_view_timing&&NREUM.init.page_view_timing.enabled===!1)){var u,s,d,p,l=t("handle"),v=t("loader"),m=t(8),g=t(3),y=NREUM.o.EV;if("PerformanceObserver"in window&&"function"==typeof window.PerformanceObserver){s=new PerformanceObserver(r);try{s.observe({entryTypes:["paint"]})}catch(h){}d=new PerformanceObserver(i);try{d.observe({entryTypes:["largest-contentful-paint"]})}catch(h){}p=new PerformanceObserver(o);try{p.observe({type:"layout-shift",buffered:!0})}catch(h){}}if("addEventListener"in document){var w=!1,b=["click","keydown","mousedown","pointerdown","touchstart"];b.forEach(function(t){document.addEventListener(t,c,g(!1))})}m(f)}},{}],7:[function(t,e,n){function r(t,e){if(!i)return!1;if(t!==i)return!1;if(!e)return!0;if(!o)return!1;for(var n=o.split("."),r=e.split("."),a=0;a<r.length;a++)if(r[a]!==n[a])return!1;return!0}var i=null,o=null,a=/Version\/(\S+)\s+Safari/;if(navigator.userAgent){var c=navigator.userAgent,f=c.match(a);f&&c.indexOf("Chrome")===-1&&c.indexOf("Chromium")===-1&&(i="Safari",o=f[1])}e.exports={agent:i,version:o,match:r}},{}],8:[function(t,e,n){function r(t){function e(){t(c&&document[c]?document[c]:document[o]?"hidden":"visible")}"addEventListener"in document&&a&&document.addEventListener(a,e,i(!1))}var i=t(3);e.exports=r;var o,a,c;"undefined"!=typeof document.hidden?(o="hidden",a="visibilitychange",c="visibilityState"):"undefined"!=typeof document.msHidden?(o="msHidden",a="msvisibilitychange"):"undefined"!=typeof document.webkitHidden&&(o="webkitHidden",a="webkitvisibilitychange",c="webkitVisibilityState")},{}],9:[function(t,e,n){function r(t,e){var n=[],r="",o=0;for(r in t)i.call(t,r)&&(n[o]=e(r,t[r]),o+=1);return n}var i=Object.prototype.hasOwnProperty;e.exports=r},{}],10:[function(t,e,n){function r(t,e,n){e||(e=0),"undefined"==typeof n&&(n=t?t.length:0);for(var r=-1,i=n-e||0,o=Array(i<0?0:i);++r<i;)o[r]=t[e+r];return o}e.exports=r},{}],11:[function(t,e,n){e.exports={exists:"undefined"!=typeof window.performance&&window.performance.timing&&"undefined"!=typeof window.performance.timing.navigationStart}},{}],ee:[function(t,e,n){function r(){}function i(t){function e(t){return t&&t instanceof r?t:t?u(t,f,a):a()}function n(n,r,i,o,a){if(a!==!1&&(a=!0),!l.aborted||o){t&&a&&t(n,r,i);for(var c=e(i),f=m(n),u=f.length,s=0;s<u;s++)f[s].apply(c,r);var p=d[w[n]];return p&&p.push([b,n,r,c]),c}}function o(t,e){h[t]=m(t).concat(e)}function v(t,e){var n=h[t];if(n)for(var r=0;r<n.length;r++)n[r]===e&&n.splice(r,1)}function m(t){return h[t]||[]}function g(t){return p[t]=p[t]||i(n)}function y(t,e){l.aborted||s(t,function(t,n){e=e||"feature",w[n]=e,e in d||(d[e]=[])})}var h={},w={},b={on:o,addEventListener:o,removeEventListener:v,emit:n,get:g,listeners:m,context:e,buffer:y,abort:c,aborted:!1};return b}function o(t){return u(t,f,a)}function a(){return new r}function c(){(d.api||d.feature)&&(l.aborted=!0,d=l.backlog={})}var f="nr@context",u=t("gos"),s=t(9),d={},p={},l=e.exports=i();e.exports.getOrSetContext=o,l.backlog=d},{}],gos:[function(t,e,n){function r(t,e,n){if(i.call(t,e))return t[e];var r=n();if(Object.defineProperty&&Object.keys)try{return Object.defineProperty(t,e,{value:r,writable:!0,enumerable:!1}),r}catch(o){}return t[e]=r,r}var i=Object.prototype.hasOwnProperty;e.exports=r},{}],handle:[function(t,e,n){function r(t,e,n,r){i.buffer([t],r),i.emit(t,e,n)}var i=t("ee").get("handle");e.exports=r,r.ee=i},{}],id:[function(t,e,n){function r(t){var e=typeof t;return!t||"object"!==e&&"function"!==e?-1:t===window?0:a(t,o,function(){return i++})}var i=1,o="nr@id",a=t("gos");e.exports=r},{}],loader:[function(t,e,n){function r(){if(!M++){var t=T.info=NREUM.info,e=m.getElementsByTagName("script")[0];if(setTimeout(u.abort,3e4),!(t&&t.licenseKey&&t.applicationID&&e))return u.abort();f(x,function(e,n){t[e]||(t[e]=n)});var n=a();c("mark",["onload",n+T.offset],null,"api"),c("timing",["load",n]);var r=m.createElement("script");0===t.agent.indexOf("http://")||0===t.agent.indexOf("https://")?r.src=t.agent:r.src=l+"://"+t.agent,e.parentNode.insertBefore(r,e)}}function i(){"complete"===m.readyState&&o()}function o(){c("mark",["domContent",a()+T.offset],null,"api")}var a=t(5),c=t("handle"),f=t(9),u=t("ee"),s=t(7),d=t(2),p=t(3),l=d.getConfiguration("ssl")===!1?"http":"https",v=window,m=v.document,g="addEventListener",y="attachEvent",h=v.XMLHttpRequest,w=h&&h.prototype,b=!1;NREUM.o={ST:setTimeout,SI:v.setImmediate,CT:clearTimeout,XHR:h,REQ:v.Request,EV:v.Event,PR:v.Promise,MO:v.MutationObserver};var E=""+location,x={beacon:"bam.nr-data.net",errorBeacon:"bam.nr-data.net",agent:"js-agent.newrelic.com/nr-1216.min.js"},O=h&&w&&w[g]&&!/CriOS/.test(navigator.userAgent),T=e.exports={offset:a.getLastTimestamp(),now:a,origin:E,features:{},xhrWrappable:O,userAgent:s,disabled:b};if(!b){t(1),t(6),m[g]?(m[g]("DOMContentLoaded",o,p(!1)),v[g]("load",r,p(!1))):(m[y]("onreadystatechange",i),v[y]("onload",r)),c("mark",["firstbyte",a.getLastTimestamp()],null,"api");var M=0}},{}],"wrap-function":[function(t,e,n){function r(t,e){function n(e,n,r,f,u){function nrWrapper(){var o,a,s,p;try{a=this,o=d(arguments),s="function"==typeof r?r(o,a):r||{}}catch(l){i([l,"",[o,a,f],s],t)}c(n+"start",[o,a,f],s,u);try{return p=e.apply(a,o)}catch(v){throw c(n+"err",[o,a,v],s,u),v}finally{c(n+"end",[o,a,p],s,u)}}return a(e)?e:(n||(n=""),nrWrapper[p]=e,o(e,nrWrapper,t),nrWrapper)}function r(t,e,r,i,o){r||(r="");var c,f,u,s="-"===r.charAt(0);for(u=0;u<e.length;u++)f=e[u],c=t[f],a(c)||(t[f]=n(c,s?f+r:r,i,f,o))}function c(n,r,o,a){if(!v||e){var c=v;v=!0;try{t.emit(n,r,o,e,a)}catch(f){i([f,n,r,o],t)}v=c}}return t||(t=s),n.inPlace=r,n.flag=p,n}function i(t,e){e||(e=s);try{e.emit("internal-error",t)}catch(n){}}function o(t,e,n){if(Object.defineProperty&&Object.keys)try{var r=Object.keys(t);return r.forEach(function(n){Object.defineProperty(e,n,{get:function(){return t[n]},set:function(e){return t[n]=e,e}})}),e}catch(o){i([o],n)}for(var a in t)l.call(t,a)&&(e[a]=t[a]);return e}function a(t){return!(t&&t instanceof Function&&t.apply&&!t[p])}function c(t,e){var n=e(t);return n[p]=t,o(t,n,s),n}function f(t,e,n){var r=t[e];t[e]=c(r,n)}function u(){for(var t=arguments.length,e=new Array(t),n=0;n<t;++n)e[n]=arguments[n];return e}var s=t("ee"),d=t(10),p="nr@original",l=Object.prototype.hasOwnProperty,v=!1;e.exports=r,e.exports.wrapFunction=c,e.exports.wrapInPlace=f,e.exports.argsToArray=u},{}]},{},["loader"]);</script>
+<title>Summer Session Calendar | UCLA Registrar’s Office</title>
+<link rel="stylesheet" href="/themes/custom/ucla_sa/fonts/proximanova.css?v=20220928150717">
+<link rel="stylesheet" href="/themes/custom/ucla_sa/css/ucla_sa.css??v=20220928150717">
+<script type="text/javascript">
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', 'UA-74929151-1']);
+  _gaq.push(['_setDomainName', 'none']);
+  _gaq.push(['_setAllowHash', true]);
+  _gaq.push(['_trackPageview']);
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+</script>
+<style type="text/css">
+[data-ucla-path="/embed/course-descriptions"] {
+  background-color: #FFF;
+  background-image: none;
+}
+[data-ucla-path="/embed/course-descriptions"] > header,
+[data-ucla-path="/embed/course-descriptions"] > footer,
+[data-ucla-path="/embed/course-descriptions"] .course-descriptions-search,
+[data-ucla-path="/embed/course-descriptions"] #block-ucla-sa-local-tasks {
+  display: none;
+}
+</style>
+</head>
+<body data-ucla-ref="registrar/calendars/summer-session-calendar" data-ucla-path="/calendars/summer-session-calendar" data-ucla-origin="https://registrar.ucla.edu" class="no-js">
+<script>document.body.classList.remove('no-js'); document.body.classList.add('js');</script>
+<header class="header">
+    <div class="skip-to-main">
+    <a href="#main">Skip to Main Content</a>
+    </div>
+            <div class="broadcast-message">
+      <div class="container">
+        <p>For information about COVID-19 policies and restrictions on campus, please visit the <a href="https://covid-19.ucla.edu/">UCLA COVID-19 resources website</a>.</p>
+      </div>
+    </div>
+        <div class="nav-topbar desktop-only">
+    <nav aria-label="Secondary Top" class="nav-secondary container">
+    <ul>
+  <li><a href="/forms">Forms</a></li>
+  <li><a href="/archives">Archives</a></li>
+</ul>
+    </nav>
+    </div>
+    <div class="headerbar container">
+          <a href="/" class="site-name"><img src="/sites/default/files/UCLA_Logo_Registrars.fw_.png" height="70" width="780" alt="UCLA Registrar&#039;s Office"></a>
+          <div class="header-right">
+      <button class="mobile-only" aria-haspopup="true" aria-controls="menus" aria-expanded="false" aria-label="Main Menus"></button>
+      <form action="/search" method="GET" class="site-search desktop-only">
+      <label for="header-search-headerbar">Search Website</label><input name="keys" type="search" placeholder="Search..." id="header-search-headerbar"><button type="submit">Search</button>
+      </form>
+      </div>
+    </div>
+    <div id="menus">
+    <form action="/search" method="GET" class="site-search mobile-only">
+      <label for="header-search-mobile-only">Search Website</label><input name="keys" type="search" placeholder="Search..." id="header-search-mobile-only"><button type="submit">Search</button>
+    </form>
+    <nav aria-label="Main" class="nav-main container">
+    <ul>
+  <li><a href="/registration-classes">Registration &amp; Classes</a>
+    <ul>
+      <li><a href="/registration-classes" aria-label="Overview of Registration and Classes">Overview</a></li>
+      <li><a href="/registration-classes/registration-and-payment">Registration and Payment</a></li>
+      <li><a href="https://sa.ucla.edu/ro/public/soc">Schedule of Classes</a></li>
+      <li><a href="/registration-classes/enrollment-policies">Enrollment Policies</a></li>
+      <li><a href="/registration-classes/enrollment-appointments">Enrollment Appointments and Passes</a></li>
+      <li><a href="/registration-classes/study-list">Study List</a></li>
+      <li><a href="/registration-classes/examinations">Examinations</a></li>
+      <li><a href="/registration-classes/absences-and-readmission">Absences and Readmission</a></li>
+      <li><a href="/registration-classes/graduation">Graduation</a></li>
+    </ul>
+</li>
+  <li><a href="/fees-residence">Fees &amp; Residence</a>
+    <ul>
+      <li><a href="/fees-residence" aria-label="Overview of Fees and Residence">Overview</a></li>
+      <li><a href="/fees-residence/residence-requirements">Residence Requirements</a></li>
+      <li><a href="https://sa.ucla.edu/RO/Fees/Public/public-fees">Annual and Term Student Fees</a></li>
+      <li><a href="/fees-residence/graduate-student-in-absentia-fees">Graduate Student in Absentia Fees</a></li>
+      <li><a href="/fees-residence/health-sciences-summer-fees-medicine-dentistry">Health Sciences Summer Fees (Medicine, Dentistry)</a></li>
+      <li><a href="/fees-residence/self-supporting-degrees">Self-Supporting Degree Fees</a></li>
+      <li><a href="/fees-residence/course-and-study-list-fees">Course and Study List Fees</a></li>
+      <li><a href="/fees-residence/document-and-service-fees">Document and Service Fees</a></li>
+      <li><a href="/fees-residence/transcript-related-fees">Transcript-Related Fees</a></li>
+      <li><a href="/fees-residence/degree-and-diploma-fees">Degree and Diploma Fees</a></li>
+      <li><a href="/fees-residence/fee-descriptions">Fee Descriptions</a></li>
+    </ul>
+</li>
+  <li><a href="/academics">Academics</a>
+    <ul>
+      <li><a href="/academics" aria-label="Overview of Academics">Overview</a></li>
+      <li><a href="http://catalog.registrar.ucla.edu/">General Catalog</a></li>
+      <li><a href="/academics/course-descriptions">Course Descriptions</a></li>
+      <li><a href="/academics/diversity-requirement">Diversity Requirement</a></li>
+      <li><a href="/academics/foreign-language-requirement">Foreign Language Requirement</a></li>
+      <li><a href="/academics/ge-requirement">GE Requirement</a></li>
+      <li><a href="/academics/writing-ii-requirement">Writing II Requirement</a></li>
+     <li><a href="/academics/foreign-literature-in-english-translation">Foreign Literature in English Translation</a></li>
+      <li><a href="/academics/departments-programs-and-freestanding-minors">Departments, Programs, and Freestanding Minors</a></li>
+      <li><a href="/academics/academic-counseling">Academic Counseling</a></li>
+    </ul>
+</li>
+  <li><a href="/student-records">Student Records</a>
+    <ul>
+      <li><a href="/student-records" aria-label="Overview of Student Records">Overview</a></li>
+      <li><a href="/student-records/personal-information">Personal Information</a></li>
+      <li><a href="/student-records/academic-transcript">Academic Transcript</a></li>
+      <li><a href="/student-records/proof-of-enrollment">Proof of Enrollment</a></li>
+      <li><a href="/student-records/transfer-credit-processing">Transfer Credit Processing</a></li>
+      <li><a href="/student-records/grades-and-academic-revisions">Grades and Academic Revisions</a></li>
+      <li><a href="/student-records/student-rights-privacy">Student Rights and Privacy</a></li>
+      <li><a href="/student-records/closure-of-student-record">Closure of Student Record</a></li>
+      <li><a href="/student-records/diplomas">Diplomas</a></li>
+      <li><a href="/student-records/notary-services">Notary Services</a></li>
+      <li><a href="/student-records/veteran-services">Veteran Services</a></li>
+      <li><a href="/student-records/professional-school-and-extension-transcripts">Professional School and Extension Transcripts</a></li>
+    </ul>
+</li>
+  <li><a href="/calendars">Calendars</a>
+    <ul>
+      <li><a href="/calendars" aria-label="Overview of Calendars">Overview</a></li>
+      <li><a href="/calendars/annual-academic-calendar">Annual Academic Calendar</a></li>
+      <li><a href="/term-calendar">Term Calendar</a></li>
+      <li><a href="/calendars/professional-school-calendars">Professional School Calendars</a></li>
+      <li><a href="/calendars/summer-session-calendar">Summer Session Calendar</a></li>
+    </ul>
+</li>
+  <li><a href="/faculty-staff">Faculty &amp; Staff</a>
+    <ul>
+      <li><a href="/faculty-staff" aria-label="Overview of Faculty and Staff">Overview</a></li>
+      <li><a href="/faculty-staff/classrooms-and-scheduling">Classrooms and Scheduling</a></li>
+      <li><a href="/faculty-staff/courses-and-programs">Courses and Programs</a></li>
+      <li><a href="/faculty-staff/accessing-student-data">Accessing Student Data</a></li>
+      <li><a href="/faculty-staff/grade-submission-deadlines">Grade Submission Deadlines</a></li>
+      <li><a href="/faculty-staff/ferpa">FERPA</a></li>
+    </ul>
+</li>
+</ul>
+    </nav>
+    <nav aria-label="Secondary Menu" class="nav-secondary container mobile-only">
+    <ul>
+  <li><a href="/forms">Forms</a></li>
+  <li><a href="/archives">Archives</a></li>
+</ul>
+    </nav>
+    </div>
+</header>
+<main id="main">
+  <div class="container">
+        <div class="page page-has-menu">
+<div class="page-header">
+  <div id="block-system-messages">
+<div data-drupal-messages-fallback class="hidden"></div>
+</div>
+<div id="block-breadcrumbs">
+  
+    
+        <nav aria-labelledby="system-breadcrumb">
+    <h2 id="system-breadcrumb" class="visually-hidden">Breadcrumb</h2>
+    <ol>
+          <li>
+                            <a href="https://registrar.ucla.edu/">Home</a>
+                        </li>
+          <li>
+                            <a href="https://registrar.ucla.edu/calendars">Calendars</a>
+                        </li>
+          <li>
+                            <a href="https://registrar.ucla.edu/calendars/summer-session-calendar">Summer Session Calendar</a>
+                        </li>
+        </ol>
+  </nav>
+
+  </div>
+<div id="block-ucla-sa-page-title">
+  
+    
+      
+  <h1>Summer Session Calendar</h1>
+
+
+  </div>
+
+
+</div>
+<div class="page-content">
+  <div id="block-mainpagecontent">
+  
+    
+      <div data-ucla-node-id="170">
+
+
+
+
+
+<div class="body-content body--section">
+
+<p class="lead">Summer classes are offered in nine sessions that differ in length, plus a variable session in which dates are specific to an individual program.</p> <p>Summer classes are published in the <a href="https://sa.ucla.edu/ro/public/soc">Schedule of Classes</a>. Detailed dates and deadlines for current-year summer sessions can be viewed on the <a href="http://www.summer.ucla.edu/calendar">Summer Sessions website</a>. <a href="https://summer.ucla.edu/PrecollegeInstitutes">Summer Institute</a>, <a href="https://ieo.ucla.edu/travelstudy/">Travel Study</a>, and <a href="https://ieo.ucla.edu/globalinternships/">Global Internship</a> programs are considered session V (as in <em>variable</em>); their dates are specific to each program.</p> <div data-custom-embed-id="439" data-custom-embed-title="Summer Session Calendar Table">
+
+<table><thead><tr><th colspan="4"><strong>Summer Sessions 2022</strong></th></tr><tr><th><strong>Session</strong></th> <th><strong>Length in Weeks</strong></th> <th><strong>Start Date</strong></th> <th><strong>End Date</strong></th></tr></thead><tbody><tr><td colspan="2"><strong>Juneteenth holiday</strong></td> <td colspan="2">June 20</td></tr><tr><td>A</td> <td>3</td> <td>June 21</td> <td>July 8</td></tr><tr><td>A</td> <td>6</td> <td>June 21</td> <td>July 29</td></tr><tr><td>A</td> <td>8</td> <td>June 21</td> <td>August 12</td></tr><tr><td>A</td> <td>9</td> <td>June 21</td> <td>August 19</td></tr><tr><td>A</td> <td>10</td> <td>June 21</td> <td>August 26</td></tr><tr><td colspan="2"><strong>Independence Day holiday</strong></td> <td colspan="2">July 4</td></tr><tr><td>B</td> <td>3</td> <td>July 11</td> <td>July 29</td></tr><tr><td>C</td> <td>3</td> <td>August 1</td> <td>August 19</td></tr><tr><td>C</td> <td>6</td> <td>August 1</td> <td>September 9</td></tr><tr><td>D</td> <td>3</td> <td>August 22</td> <td>September 9</td></tr><tr><td colspan="2"><strong>Labor Day holiday</strong></td> <td colspan="2">September 5</td></tr></tbody></table></div>
+
+
+
+</div>
+
+
+
+
+</div>
+  </div>
+
+
+</div>
+<div class="page-menu">
+  <nav aria-labelledby="section-menu-title" class="section-menu">
+<h2 id="section-menu-title" class="section-menu-title"><a href="/calendars" data-drupal-link-system-path="node/166">Calendars</a></h2>
+<ul>
+<li class="section-menu-item"><a href="/calendars/annual-academic-calendar" data-drupal-link-system-path="node/167">Annual Academic Calendar</a></li>
+<li class="section-menu-item"><a href="/term-calendar" data-drupal-link-system-path="node/208">Term Calendar</a></li>
+<li class="section-menu-item"><a href="/calendars/professional-school-calendars" data-drupal-link-system-path="node/169">Professional School Calendars</a></li>
+<li class="section-menu-item section-menu-item-active"><a href="/calendars/summer-session-calendar" data-drupal-link-system-path="node/170" class="is-active">Summer Session Calendar</a></li>
+</ul>
+</nav>
+
+
+
+</div>
+</div>
+
+
+      </div>
+</main>
+<footer>
+<div class="container">
+<nav class="nav-footer" aria-label="Footer">
+  <ul>\n  <li><a href="/about-the-registrars-office">About</a></li>\n  <li><a href="/contacts-hours">Contacts/Hours</a></li>\n  <li><a href="https://my.ucla.edu/">MyUCLA</a></li>\n  <li><a href="https://www.studentaffairs.ucla.edu/">Student Affairs</a></li>\n  <li><a href="https://www.ucla.edu/">UCLA.edu</a></li>\n  <li><a href="/voter-information">Register to Vote</a></li>\n</ul>
+
+</nav>
+</div>
+</footer>
+<script src="/themes/custom/ucla_sa/js/ucla_sa.js?v=a20220928150717" async></script>
+<script type="text/javascript">
+(function() {
+  if(document.querySelector('[data-ucla]')) {
+    var embed = document.createElement('script'); embed.type = 'text/javascript'; embed.async = true;
+    embed.src = '/themes/custom/ucla_sa/js/ucla_embed.js?v=20220928150717';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(embed, s);
+  }
+})();
+</script>
+<script type="text/javascript">window.NREUM||(NREUM={});NREUM.info={"beacon":"bam.nr-data.net","licenseKey":"NRJS-7be76d7c7bc415dd4df","applicationID":"1468364564","transactionName":"MlxTZhRUCxJYB0cLCQsWcFESXAoPFhRSBQM6WlBRDlA=","queueTime":0,"applicationTime":16,"atts":"HhtQEFxOGBw=","errorBeacon":"bam.nr-data.net","agent":""}</script></body>
+</html>


### PR DESCRIPTION
## Description

<!--- What this PR does, why we're making it, etc. -->

Allows us to scrape and add 2022 summer dates. A little late, but better than never!

## Deployment

- [ ] I am making a frontend change, which will be auto-deployed via Heroku.
- [ ] I am making a Ruby change, which will be auto-deployed via Heroku.
  - [ ] I have added one or more gems, and run `rake sorbet:update:all` to generate their types.
  - [ ] I have added or changed a model, and run `rake sorbet:update:all` to generate their types.
- [ ] I am making a database change, which I will manually deploy after my branch is merged.
  - [ ] I have migrated the database using `env RAILS_ENV=production rails db:migrate`.
  - [ ] I have updated the entity relationship diagram via `bundle exec erd`.
  - [ ] I have updated the affected Administrate model dashboards to reflect my DB changes.
- [ ] I am making a Go Lambda change, which I will manually deploy after my branch is merged.
  - [ ] I have deployed the lambdas using `make deploy`.
- [ ] There are other deployment steps I must take after merge, which are:
```
rake scrape:summer_session_dates[2022]
```
