### PR TITLE
Add a one-click unsubscribe link to text messages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,8 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :set_referral_cookie
 
+  include Devise::Controllers::Helpers
+
   # Required by Devise
   # https://github.com/heartcombo/devise/wiki/OmniAuth%3A-Overview#using-omniauth-without-other-authentications
   sig { params(_scope: T.untyped).returns(String) }
@@ -13,9 +15,9 @@ class ApplicationController < ActionController::Base
     new_user_session_path
   end
 
-  sig { params(_user: T.untyped).returns(T.untyped) }
-  def after_sign_in_path_for(_user)
-    my_courses_path
+  sig { params(resource_or_scope: T.untyped).returns(T.untyped) }
+  def after_sign_in_path_for(resource_or_scope)
+    stored_location_for(resource_or_scope) || super
   end
 
   sig { void }
@@ -51,5 +53,23 @@ class ApplicationController < ActionController::Base
                       else
                         'ERROR'
                       end
+  end
+
+  private
+
+  # Its important that the location is NOT stored if:
+  # - The request method is not GET (non idempotent)
+  # - The request is handled by a Devise controller such as Devise::SessionsController as that could cause an
+  #    infinite redirect loop.
+  # - The request is an Ajax request as this can lead to very unexpected behaviour.
+  sig { returns(T::Boolean) }
+  def storable_location?
+    request.get? && is_navigational_format? && !devise_controller? && !request.xhr?
+  end
+
+  sig { returns(T.untyped) }
+  def store_user_location!
+    # :user is the scope we are authenticating
+    store_location_for(:user, request.fullpath)
   end
 end

--- a/app/controllers/application_controller.rbi
+++ b/app/controllers/application_controller.rbi
@@ -7,7 +7,4 @@ class ApplicationController
 
   sig { returns(T::Boolean) }
   def user_signed_in?; end
-
-  sig { params(resource_or_scope: T.untyped).void }
-  def sign_in_and_redirect(resource_or_scope); end
 end

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -3,6 +3,7 @@
 
 class CheckoutsController < ApplicationController
   extend T::Sig
+  before_action :store_user_location!, if: :storable_location?
   before_action :authenticate_user!
 
   sig { void }

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -16,6 +16,10 @@ class RelationshipsController < ApplicationController
     const :subscription_only, T::Boolean
   end
 
+  class UnsubscribeParams < T::Struct
+    const :id, Integer
+  end
+
   sig { void }
   def create
     typed_params = TypedParams[CreateParams].new.extract!(params)
@@ -49,6 +53,22 @@ class RelationshipsController < ApplicationController
         render json: { msg: "You cannot unfollow a class you've reviewed! Did you mean to unsubscribe?" }, status: :bad_request
       end
     end
+  end
+
+  sig { void }
+  def unsubscribe
+    typed_params = TypedParams[UnsubscribeParams].new.extract!(params)
+    user = T.must(current_user)
+    section = Section.find(typed_params.id)
+    course = section.course
+
+    successfully_unsubscribed = user.unsubscribe(section)
+    if successfully_unsubscribed
+      flash[:success] = "Unsubscribed to alerts for #{course.short_title}"
+    else
+      flash[:error] = "You aren't subscribed to notifications for #{course.short_title}!"
+    end
+    redirect_to my_courses_url
   end
 
   private

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -4,6 +4,7 @@
 class ReviewsController < ApplicationController
   extend T::Sig
 
+  before_action :store_user_location!, if: :storable_location?
   before_action :authenticate_user!
 
   class ReviewParams < T::Struct

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,6 +6,7 @@ require 'twilio-ruby'
 class UsersController < ApplicationController
   extend T::Sig
 
+  before_action :store_user_location!, if: :storable_location?
   before_action :authenticate_user!
 
   sig { void }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -136,7 +136,7 @@ class User < ApplicationRecord
   sig { params(section: Section).returns(T::Boolean) }
   def unsubscribe(section)
     relationship = relationships.find_by(section:)
-    if relationship
+    if relationship&.notify
       relationship.update(notify: false)
       true
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -133,10 +133,15 @@ class User < ApplicationRecord
   end
 
   # Stops subscribing to a section. User will still be following section.
-  sig { params(section: Section).void }
+  sig { params(section: Section).returns(T::Boolean) }
   def unsubscribe(section)
     relationship = relationships.find_by(section:)
-    relationship&.update(notify: false)
+    if relationship
+      relationship.update(notify: false)
+      true
+    else
+      false
+    end
   end
 
   # Give the user a notification token and saves the new value.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
   resources 'users', only: %i[update]
 
   resources 'relationships', only: %i[create destroy]
+  get '/unsubscribe/:id', to: 'relationships#unsubscribe'
 
   # 404 and 500 pages
   match '/404', to: 'errors#not_found', via: :all

--- a/lambdas/fetch-sections/notify.go
+++ b/lambdas/fetch-sections/notify.go
@@ -48,6 +48,8 @@ func FormatMessage(
 		message += fmt.Sprintf("\n\nEnroll now: https://hotseat.io/enroll/%d", section.ID)
 	}
 
+	message += fmt.Sprintf("\n\nAlready enrolled? Unsubscribe: https://hotseat.io/unsubscribe/%d", section.ID)
+
 	return message
 }
 

--- a/test/integration/relationships_test.rb
+++ b/test/integration/relationships_test.rb
@@ -1,0 +1,35 @@
+# typed: strict
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RelatioshipTest < ActionDispatch::IntegrationTest
+  describe 'GET /unsubscribe/:section_id' do
+    it 'unsubscribes to course alerts' do
+      term = T.let(create_current_term, Term)
+      user = T.let(create(:user), User)
+      course = T.let(create(:course), Course)
+      section = T.let(create(:section, course:, term:), Section)
+      create :relationship, user: user, section: section, notify: true
+      sign_in user
+
+      get "/unsubscribe/#{section.id}"
+
+      assert_redirected_to '/my-courses'
+      assert_equal "Unsubscribed to alerts for #{course.short_title}", flash[:success]
+    end
+
+    it 'gives an error message when unsubscribing from a non-followed course' do
+      term = T.let(create_current_term, Term)
+
+      course = T.let(create(:course), Course)
+      section = T.let(create(:section, course:, term:), Section)
+      sign_in create(:user)
+
+      get "/unsubscribe/#{section.id}"
+
+      assert_redirected_to '/my-courses'
+      assert_equal "You aren't subscribed to notifications for #{course.short_title}!", flash[:error]
+    end
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -38,7 +38,7 @@ class UserTest < ActiveSupport::TestCase
     assert_not invalid_user.valid?
   end
 
-  describe 'unfollow' do
+  describe '#unfollow' do
     before do
       @term = T.let(create(:term), Term)
       @user = T.let(create(:user), User)
@@ -61,7 +61,7 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
-  describe 'add_notification_token' do
+  describe '#add_notification_token' do
     it 'adds a single notification token to a user' do
       user = build :user, notification_token_count: 1
       user.add_notification_token
@@ -141,6 +141,28 @@ class UserTest < ActiveSupport::TestCase
       create :user, referral_code: referral_code
       user = build :user
       assert_raises(ActiveRecord::ActiveRecordError) { user.set_referral_code }
+    end
+  end
+
+  describe '#unsubscribe' do
+    it 'marks a relationship as notify=false' do
+      term = T.let(create(:term), Term)
+      user = T.let(create(:user), User)
+      section = T.let(create(:section, term:), Section)
+      relationship = create :relationship, user: user, section: section
+
+      assert(user.unsubscribe(section))
+
+      relationship.reload
+      assert_not(relationship.notify)
+    end
+
+    it 'returns false if there is no relationship' do
+      term = T.let(create(:term), Term)
+      user = T.let(create(:user), User)
+      section = T.let(create(:section, term:), Section)
+
+      assert_not(user.unsubscribe(section))
     end
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -149,12 +149,21 @@ class UserTest < ActiveSupport::TestCase
       term = T.let(create(:term), Term)
       user = T.let(create(:user), User)
       section = T.let(create(:section, term:), Section)
-      relationship = create :relationship, user: user, section: section
+      relationship = create :relationship, user: user, section: section, notify: true
 
       assert(user.unsubscribe(section))
 
       relationship.reload
       assert_not(relationship.notify)
+    end
+
+    it "returns false if the relationship didn't have notify set" do
+      term = T.let(create(:term), Term)
+      user = T.let(create(:user), User)
+      section = T.let(create(:section, term:), Section)
+      create :relationship, user: user, section: section, notify: false
+
+      assert_not(user.unsubscribe(section))
     end
 
     it 'returns false if there is no relationship' do


### PR DESCRIPTION
## Description

<!--- What this PR does, why we're making it, etc. -->

Adds a line to text message alerts to make it easy to unsubscribe to messages. Closes #29.

## Deployment

- [ ] I am making a frontend change, which will be auto-deployed via Heroku.
- [x] I am making a Ruby change, which will be auto-deployed via Heroku.
  - [ ] I have added one or more gems, and run `rake sorbet:update:all` to generate their types.
  - [ ] I have added or changed a model, and run `rake sorbet:update:all` to generate their types.
- [ ] I am making a database change, which I will manually deploy after my branch is merged.
  - [ ] I have migrated the database using `env RAILS_ENV=production rails db:migrate`.
  - [ ] I have updated the entity relationship diagram via `bundle exec erd`.
  - [ ] I have updated the affected Administrate model dashboards to reflect my DB changes.
- [x] I am making a Go Lambda change, which I will manually deploy after my branch is merged.
  - [ ] I have deployed the lambdas using `make deploy`.
- [ ] There are other deployment steps I must take after merge, which are:
