### PR TITLE
Don't render ads or analytics in test env

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -72,9 +72,10 @@ module ApplicationHelper
 
   sig { returns(T::Boolean) }
   def show_ads?
-    !(current_page?(root_path) or
+    (!(current_page?(root_path) or
     current_page?(page_path("privacy")) or
     current_page?(page_path("terms")) or
-    current_page?(page_path("faq")))
+      current_page?(page_path("faq"))) and !T.unsafe(Rails.env).test?
+    )
   end
 end

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -31,14 +31,16 @@
   <%= csp_meta_tag %>
 
   <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-QMXHM0BW9X"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
+  <% if T.unsafe(Rails.env).production? %>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-QMXHM0BW9X"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-    gtag('config', 'G-QMXHM0BW9X');
-  </script>
+      gtag('config', 'G-QMXHM0BW9X');
+    </script>
+  <% end %>
 
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
   <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>

--- a/app/views/shared/_card_ad.html.erb
+++ b/app/views/shared/_card_ad.html.erb
@@ -1,14 +1,16 @@
-<%= render "shared/card", id: "sponsored-card", title: "Sponsored Content" do %>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6727426254676046"
-      crossorigin="anonymous"></script>
-  <!-- Hotseat in-content -->
-  <ins class="adsbygoogle"
-      style="display:block"
-      data-ad-client="ca-pub-6727426254676046"
-      data-ad-slot="4516536953"
-      data-ad-format="auto"
-      data-full-width-responsive="true"></ins>
-  <script>
-      (adsbygoogle = window.adsbygoogle || []).push({});
-  </script>
+<% if show_ads? %>
+    <%= render "shared/card", id: "sponsored-card", title: "Sponsored Content" do %>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6727426254676046"
+        crossorigin="anonymous"></script>
+    <!-- Hotseat in-content -->
+    <ins class="adsbygoogle"
+        style="display:block"
+        data-ad-client="ca-pub-6727426254676046"
+        data-ad-slot="4516536953"
+        data-ad-format="auto"
+        data-full-width-responsive="true"></ins>
+    <script>
+        (adsbygoogle = window.adsbygoogle || []).push({});
+    </script>
+    <% end %>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ Bundler.require(*Rails.groups)
 
 module HotseatIo
   class Application < Rails::Application
-    config.load_defaults(6.1)
+    config.load_defaults(7.0)
 
     config.exceptions_app = routes
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,7 @@ module HotseatIo
     config.exceptions_app = routes
 
     config.active_record.schema_format = :sql
+    config.active_support.remove_deprecated_time_with_zone_name = true
 
     # Async is a fine ActiveJob adapter while our only job is the Slack notifier, but
     # we'll probably want something more robust if we add other jobs.

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -5,6 +5,7 @@ require "test_helper"
 require "capybara/cuprite"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  extend T::Sig
   include FactoryBot::Syntax::Methods
   include Capybara::DSL
   include Devise::Test::IntegrationHelpers

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -15,7 +15,8 @@ FactoryBot.define do
   factory :term do
     sequence(:term) do |n|
       quarters = %w[W S F 1]
-      years = %w[99 00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27]
+      # Note that 21 is missing: we explicitly omit it since `21S` is our "current" term in tests
+      years = %w[99 00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 22 23 24 25 26 27]
       years.product(quarters).map(&:join)[n]
     end
   end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -37,4 +37,48 @@ class ApplicationHelperTest < ActionView::TestCase
       assert_equal("information-circle", get_alert_symbol("blah"))
     end
   end
+
+  describe "#show_ads" do
+    it "doesn't show ads in test mode" do
+      T.unsafe(Rails).stubs(:env).returns(ActiveSupport::StringInquirer.new("test"))
+      T.unsafe(self).expects(:current_page?).times(4).returns(false)
+      assert_not(show_ads?)
+    end
+
+    it "doesn't show ads on the home page" do
+      T.unsafe(Rails).stubs(:env).returns(ActiveSupport::StringInquirer.new("production"))
+      T.unsafe(self).expects(:current_page?).with(root_path).returns(true)
+      assert_not(show_ads?)
+    end
+
+    it "doesn't show ads on the privacy page" do
+      T.unsafe(Rails).stubs(:env).returns(ActiveSupport::StringInquirer.new("production"))
+      T.unsafe(self).expects(:current_page?).with(root_path).returns(false)
+      T.unsafe(self).expects(:current_page?).with(page_path("privacy")).returns(true)
+      assert_not(show_ads?)
+    end
+
+    it "doesn't show ads on the terms page" do
+      T.unsafe(Rails).stubs(:env).returns(ActiveSupport::StringInquirer.new("production"))
+      T.unsafe(self).expects(:current_page?).with(root_path).returns(false)
+      T.unsafe(self).expects(:current_page?).with(page_path("privacy")).returns(false)
+      T.unsafe(self).expects(:current_page?).with(page_path("terms")).returns(true)
+      assert_not(show_ads?)
+    end
+
+    it "doesn't show ads on the faq" do
+      T.unsafe(Rails).stubs(:env).returns(ActiveSupport::StringInquirer.new("production"))
+      T.unsafe(self).expects(:current_page?).with(root_path).returns(false)
+      T.unsafe(self).expects(:current_page?).with(page_path("privacy")).returns(false)
+      T.unsafe(self).expects(:current_page?).with(page_path("terms")).returns(false)
+      T.unsafe(self).expects(:current_page?).with(page_path("faq")).returns(true)
+      assert_not(show_ads?)
+    end
+
+    it "shows ads otherwise" do
+      T.unsafe(Rails).stubs(:env).returns(ActiveSupport::StringInquirer.new("production"))
+      T.unsafe(self).expects(:current_page?).times(4).returns(false)
+      assert_predicate(self, :show_ads?)
+    end
+  end
 end

--- a/test/integration/courses_test.rb
+++ b/test/integration/courses_test.rb
@@ -14,7 +14,6 @@ class CoursesTest < ActionDispatch::IntegrationTest
 
   describe "GET /courses/:id" do
     it "redirects to the most recent instructor's page if there is an instructor" do
-      # path = T.let(nil, T.nilable(String))
       term = create_current_term
       prev_term = create(:term)
 

--- a/test/integration/reviews_test.rb
+++ b/test/integration/reviews_test.rb
@@ -65,10 +65,7 @@ class ReviewsTest < ActionDispatch::IntegrationTest
                                number: "30",
                                id: 6,
                                preceding_course:)
-      create_list(:section, 6, course:) do |section, i|
-        section.term = create(:term, term: "3#{i}W")
-      end
-
+      create_list(:section, 6, course:)
       get "/reviews/term-suggestions?course_id=#{course.id}"
 
       assert_response :ok

--- a/test/integration/reviews_test.rb
+++ b/test/integration/reviews_test.rb
@@ -56,7 +56,7 @@ class ReviewsTest < ActionDispatch::IntegrationTest
 
   describe "GET /reviews/term-suggestions" do
     it "provides the terms a given course has been offered under" do
-      create_current_term
+      term = create_current_term
       sign_in create(:user)
       com_sci = create(:subject_area, name: "Computer Science", code: "COM SCI")
       preceding_course = create(:course, subject_area: com_sci, title: "Introduction to the Boop Beep", number: "30", id: 5)
@@ -65,7 +65,9 @@ class ReviewsTest < ActionDispatch::IntegrationTest
                                number: "30",
                                id: 6,
                                preceding_course:)
-      create_list(:section, 6, course:)
+      create_list(:section, 6, course:) do |section, i|
+        section.term = create(:term, term: "3#{i}W")
+      end
 
       get "/reviews/term-suggestions?course_id=#{course.id}"
 

--- a/test/integration/reviews_test.rb
+++ b/test/integration/reviews_test.rb
@@ -56,7 +56,7 @@ class ReviewsTest < ActionDispatch::IntegrationTest
 
   describe "GET /reviews/term-suggestions" do
     it "provides the terms a given course has been offered under" do
-      term = create_current_term
+      create_current_term
       sign_in create(:user)
       com_sci = create(:subject_area, name: "Computer Science", code: "COM SCI")
       preceding_course = create(:course, subject_area: com_sci, title: "Introduction to the Boop Beep", number: "30", id: 5)


### PR DESCRIPTION
## Description

<!--- What this PR does, why we're making it, etc. -->

Title.

## Deployment

- [x] I am making a frontend change, which will be auto-deployed via Heroku.
- [x] I am making a Ruby change, which will be auto-deployed via Heroku.
  - [ ] I have added one or more gems, and run `rake sorbet:update:all` to generate their types.
  - [ ] I have added or changed a model, and run `rake sorbet:update:all` to generate their types.
- [ ] I am making a database change, which I will manually deploy after my branch is merged.
  - [ ] I have migrated the database using `env RAILS_ENV=production rails db:migrate`.
  - [ ] I have updated the entity relationship diagram via `bundle exec erd`.
  - [ ] I have updated the affected Administrate model dashboards to reflect my DB changes.
- [ ] I am making a Go Lambda change, which I will manually deploy after my branch is merged.
  - [ ] I have deployed the lambdas using `make deploy`.
- [ ] There are other deployment steps I must take after merge, which are:
