### PR TITLE
allow_other_host: true on enrollment link

### DIFF
--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -13,6 +13,6 @@ class SectionsController < ApplicationController
   def enroll
     typed_params = TypedParams[EnrollParams].new.extract!(params)
     section = Section.find(typed_params.id)
-    redirect_to(section.enroll_link)
+    redirect_to(section.enroll_link, allow_other_host: true)
   end
 end


### PR DESCRIPTION
## Description

<!--- What this PR does, why we're making it, etc. -->

Fix an error on the enrollment link with new Rails settings!

## Deployment

- [ ] I am making a frontend change, which will be auto-deployed via Heroku.
- [x] I am making a Ruby change, which will be auto-deployed via Heroku.
  - [ ] I have added one or more gems, and run `rake sorbet:update:all` to generate their types.
  - [ ] I have added or changed a model, and run `rake sorbet:update:all` to generate their types.
- [ ] I am making a database change, which I will manually deploy after my branch is merged.
  - [ ] I have migrated the database using `env RAILS_ENV=production rails db:migrate`.
  - [ ] I have updated the entity relationship diagram via `bundle exec erd`.
  - [ ] I have updated the affected Administrate model dashboards to reflect my DB changes.
- [ ] I am making a Go Lambda change, which I will manually deploy after my branch is merged.
  - [ ] I have deployed the lambdas using `make deploy`.
- [ ] There are other deployment steps I must take after merge, which are:
