### PR TITLE
Do not award notification token unless review is approved

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -138,8 +138,6 @@ class ReviewsController < ApplicationController
       status: "pending",
     )
 
-    user.add_notification_token
-
     logger.info("Queueing NotifyOnNewReviewJob")
     NotifyOnNewReviewJob.perform_later(review)
 

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -145,7 +145,6 @@ class ReviewsController < ApplicationController
     # so we store a session variable instead
     if is_first_review && user.referred_by
       session[:referred_review_created] = true
-      user.complete_referral!
     else
       session[:review_submitted] = true
     end

--- a/test/system/referral_test.rb
+++ b/test/system/referral_test.rb
@@ -91,7 +91,7 @@ class ReferralTest < ApplicationSystemTestCase
 
     # +1 token for the referrer
     assert_equal(1, referring_user.notification_token_count)
-    # +2 tokens for the referree
-    assert_equal(3, user.notification_token_count)
+    # +1 token for the referree
+    assert_equal(2, user.notification_token_count)
   end
 end

--- a/test/system/referral_test.rb
+++ b/test/system/referral_test.rb
@@ -67,7 +67,7 @@ class ReferralTest < ApplicationSystemTestCase
   test "user fills out their phone number and beta testing status" do
     create_current_term
 
-    referring_user = create(:user, name: "Nathan Smith", notification_token_count: 0)
+    referring_user = create(:user, name: "Nathan Smith", notification_token_count: 100)
     user = create(:user, referred_by: referring_user, notification_token_count: 1)
 
     subj_area = create(:subject_area)
@@ -86,12 +86,22 @@ class ReferralTest < ApplicationSystemTestCase
     assert_current_path "/my-courses"
     assert_text page, "Review submitted! Since you were referred by Nathan Smith, you'll receive 2 notification tokens once your review is approved. (We'll text you when that happens!)", wait: 10
 
+    # No tokens yet
     referring_user.reload
     user.reload
+    assert_equal(100, referring_user.notification_token_count)
+    assert_equal(1, user.notification_token_count)
 
-    # +1 token for the referrer
-    assert_equal(1, referring_user.notification_token_count)
-    # +1 token for the referree
-    assert_equal(2, user.notification_token_count)
+    # TODO: add review.approve! to check what happens after the review is approved.
+    #
+    # review = ...
+    # review.approve!
+    #
+    # referring_user.reload
+    # user.reload
+    # # +1 token for the referrer
+    # assert_equal(101, referring_user.notification_token_count)
+    # # +2 token for the referree
+    # assert_equal(3, user.notification_token_count)
   end
 end

--- a/test/system/reviews_system_test.rb
+++ b/test/system/reviews_system_test.rb
@@ -94,7 +94,7 @@ class ReviewsSystemTest < ApplicationSystemTestCase
     assert_equal review_text, review.comments
 
     user.reload
-    assert_equal(1, user.notification_token_count)
+    assert_equal(0, user.notification_token_count)
   end
 
   it "allows users to write reviews with section preloaded" do
@@ -169,9 +169,10 @@ class ReviewsSystemTest < ApplicationSystemTestCase
     assert review.reccomend_textbook
     assert_not review.offers_extra_credit
     assert_equal review_text, review.comments
+    assert_equal "pending", review.status
 
     user.reload
-    assert_equal(1, user.notification_token_count)
+    assert_equal(0, user.notification_token_count)
   end
 
   describe "review editing" do
@@ -241,6 +242,9 @@ class ReviewsSystemTest < ApplicationSystemTestCase
 
     it "allows for changing the review" do
       sign_in @user
+      @user.reload
+      prev_tokens = @user.notification_token_count
+
       visit "/reviews/#{@review.id}/edit"
       review_text = "I've thought about my review some more and wanted to change what I wrote because I'm now taking another class that made me think about this professor in a new light!"
 
@@ -251,6 +255,10 @@ class ReviewsSystemTest < ApplicationSystemTestCase
 
       @review.reload
       assert_equal(review_text, @review.comments)
+      assert_equal("pending", @review.status)
+
+      @user.reload
+      assert_equal(prev_tokens, @user.notification_token_count)
     end
   end
 end


### PR DESCRIPTION
## Description

Remove stray line that awards token to unapproved reviews.

## Deployment

- [x] I am making a Ruby change, which will be auto-deployed via Heroku.
