### PR TITLE
Create a data migration to backfill `first_approved_at`

### DIFF
--- a/lib/tasks/data_migration/backfill_review_first_approved_at.rake
+++ b/lib/tasks/data_migration/backfill_review_first_approved_at.rake
@@ -1,0 +1,20 @@
+# typed: strict
+# frozen_string_literal: true
+
+extend Rake::DSL # rubocop:disable Style/MixinUsage
+
+namespace :data_migration do
+  desc "Backfill the first_approved_at date for already approved reviews"
+  task backfill_review_first_approved_at: :environment do
+    Rails.logger = Logger.new($stdout)
+    ActiveRecord::Base.logger = Rails.logger
+
+    # Change to :debug for ActiveRecord SQL logs.
+    Rails.logger.level = :info
+
+    ActiveRecord::Base.transaction do
+      reviews = Review.where(status: "approved", first_approved_at: nil)
+      reviews.update_all(first_approved_at: Time.zone.now)
+    end
+  end
+end


### PR DESCRIPTION
## Description

<!--- What this PR does, why we're making it, etc. -->

Introduces a new data migration (runnable as `rake data_migration:backfill_review_first_approved_at`) to set `first_approved_at` on all approved reviews with `first_approved_at = nil`.

## Deployment

- [ ] I am making a frontend change, which will be auto-deployed via Heroku.
- [ ] I am making a Ruby change, which will be auto-deployed via Heroku.
  - [ ] I have added one or more gems, and run `rake sorbet:update:all` to generate their types.
  - [ ] I have added or changed a model, and run `rake sorbet:update:all` to generate their types.
- [ ] I am making a database change, which I will manually deploy after my branch is merged.
  - [ ] I have migrated the database using `env RAILS_ENV=production rails db:migrate`.
  - [ ] I have updated the entity relationship diagram via `bundle exec erd`.
  - [ ] I have updated the affected Administrate model dashboards to reflect my DB changes.
- [ ] I am making a Go Lambda change, which I will manually deploy after my branch is merged.
  - [ ] I have deployed the lambdas using `make deploy`.
- [x] There are other deployment steps I must take after merge, which are:
```
rake data_migration:backfill_review_first_approved_at
```
