### PR TITLE
Remove VPC for lambdas

### DIFF
--- a/lambdas/serverless.yml
+++ b/lambdas/serverless.yml
@@ -7,13 +7,6 @@ provider:
   timeout: 120
   region: 'us-east-1'
   versionFunctions: false
-  vpc:
-    securityGroupIds:
-      - ${env:AWS_SECURITY_GROUP_ID}
-    subnetIds:
-      - ${env:AWS_SUBNET_ID_1}
-      - ${env:AWS_SUBNET_ID_2}
-      - ${env:AWS_SUBNET_ID_3}
   iam:
     role:
       statements:


### PR DESCRIPTION
## Description

<!--- What this PR does, why we're making it, etc. -->

We no longer use the RDS Proxy, so the VPCs aren't needed.

## Deployment

- [ ] I am making a frontend change, which will be auto-deployed via Heroku.
- [ ] I am making a Ruby change, which will be auto-deployed via Heroku.
  - [ ] I have added one or more gems, and run `rake sorbet:update:all` to generate their types.
  - [ ] I have added or changed a model, and run `rake sorbet:update:all` to generate their types.
- [ ] I am making a database change, which I will manually deploy after my branch is merged.
  - [ ] I have migrated the database using `env RAILS_ENV=production rails db:migrate`.
  - [ ] I have updated the entity relationship diagram via `bundle exec erd`.
  - [ ] I have updated the affected Administrate model dashboards to reflect my DB changes.
- [x] I am making a Go Lambda change, which I will manually deploy after my branch is merged.
  - [x] I have deployed the lambdas using `make deploy`.
- [ ] There are other deployment steps I must take after merge, which are:
