### PR TITLE
Add migration to backfill users to announcements mailing list

### DIFF
--- a/lib/tasks/data_migration/backfill_subscribers_to_announcements_mailing_list.rake
+++ b/lib/tasks/data_migration/backfill_subscribers_to_announcements_mailing_list.rake
@@ -1,0 +1,22 @@
+# typed: strict
+# frozen_string_literal: true
+
+extend Rake::DSL # rubocop:disable Style/MixinUsage
+
+namespace :data_migration do
+  desc "Backfill the first_approved_at date for already approved reviews"
+  task backfill_subscribers_to_announcements_mailing_list: :environment do
+    Rails.logger = Logger.new($stdout)
+    ActiveRecord::Base.logger = Rails.logger
+
+    # Change to :debug for ActiveRecord SQL logs.
+    Rails.logger.level = :info
+
+    ActiveRecord::Base.transaction do
+      User.all.find_each do |user|
+        user.subscribe("announcements") unless user.subscribed?("announcements")
+        user.save
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

<!--- What this PR does, why we're making it, etc. -->

## Deployment

- [ ] I am making a frontend change, which will be auto-deployed via Heroku.
- [ ] I am making a Ruby change, which will be auto-deployed via Heroku.
  - [ ] I have added one or more gems, and run `rake sorbet:update:all` to generate their types.
  - [ ] I have added or changed a model, and run `rake sorbet:update:all` to generate their types.
- [ ] I am making a database change, which I will manually deploy after my branch is merged.
  - [ ] I have migrated the database using `env RAILS_ENV=production rails db:migrate`.
  - [ ] I have updated the entity relationship diagram via `bundle exec erd`.
  - [ ] I have updated the affected Administrate model dashboards to reflect my DB changes.
- [ ] I am making a Go Lambda change, which I will manually deploy after my branch is merged.
  - [ ] I have deployed the lambdas using `make deploy`.
- [x] There are other deployment steps I must take after merge, which are:
```
dokku run rake data_migration:backfill_subscribers_to_announcements_mailing_list
```
